### PR TITLE
[JENKINS-20908] - Use Mailer plugin instead of internal FastMailResolver implementation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>mailer</artifactId>
-            <version>1.5</version>
+            <version>1.6</version>
             <type>jar</type>
         </dependency>
     </dependencies>


### PR DESCRIPTION
Resolves https://issues.jenkins-ci.org/browse/JENKINS-20908

Signed-off-by: Oleg Nenashev nenashev@synopsys.com
